### PR TITLE
'allow' now puts machine into same state that 'disallow' does.

### DIFF
--- a/robotparser.nim
+++ b/robotparser.nim
@@ -223,6 +223,7 @@ proc parse*(robot : RobotParser, lines : seq[string]) =
                  state = 2
              elif lineSeq[0] == "allow":
                  entry.rules = entry.rules.concat(@[createRule(lineSeq[1], true)])
+                 state = 2
          if state == 2:
              robot.entries = robot.entries.concat(@[entry])
              


### PR DESCRIPTION
i fixed this a long time ago in robotparser.py.  as i recall the symptom was that if an 'allow' came last, then it had no effect.
